### PR TITLE
Merchant item enable disable jr

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -15,19 +15,26 @@ class MerchantItemsController < ApplicationController
 
   def update
     item = Item.find(params[:item_id])
-    if item.update(item_params)
+    # binding.pry
+    if params[:status] == "1"
+      item.update(status: 1)
+      redirect_to "/merchants/#{item.merchant.id}/items/"
+    elsif params[:status] == "0"
+      item.update(status: 0)
+      redirect_to "/merchants/#{item.merchant.id}/items/"
+    elsif item.update(item_params)
       redirect_to "/merchants/#{item.merchant.id}/items/#{item.id}"
       flash[:notice] = "Success: Item information has been updated."
     else
       redirect_to "/merchants/#{item.merchant.id}/items/#{item.id}"
     end
   end
-  
+
   private
 
   def item_params
     params.permit(:name, :description, :unit_price)
   end
-  
-  
+
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 class Item < ApplicationRecord
   belongs_to :merchant
 
+  enum status: [:disabled, :enabled]
+
   # def self.merchants_items_all
   #   binding.pry
   # end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -3,5 +3,8 @@
 <% @items.each do |item| %>
   <div id="item-<%= item.id %>">
     <p><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
+    <p>Current Status: <%= item.status %></p>
+    <p><%= button_to "Enable #{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: { status: 1} %></p>
+    <p><%= button_to "Disable #{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: { status: 0} %></p>
   </div>
 <% end %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,7 @@
 <h2><%= @merchant.name %></h2>
 
 <% @items.each do |item| %>
-  <p><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
+  <div id="item-<%= item.id %>">
+    <p><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
+  </div>
 <% end %>

--- a/db/migrate/20220531202509_add_status_to_items.rb
+++ b/db/migrate/20220531202509_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_27_204634) do
+ActiveRecord::Schema.define(version: 2022_05_31_202509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2022_05_27_204634) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -37,11 +37,35 @@ RSpec.describe 'merchants items index' do
     # Then I am redirected back to the items index
     # And I see that the items status has changed
     merch1 = Merchant.create!(name: 'Floopy Fopperations')
-    item1 = merch1.items.create!(name: 'Floopy Original', description: 'the best', unit_price: 450)
-    item2 = merch1.items.create!(name: 'Floopy Updated', description: 'the better', unit_price: 950)
-    item3 = merch1.items.create!(name: 'Floopy Retro', description: 'the OG', unit_price: 550)
+    item1 = merch1.items.create!(name: 'Floopy Original', description: 'the best', unit_price: 450, status: 0)
+    item2 = merch1.items.create!(name: 'Floopy Updated', description: 'the better', unit_price: 950, status: 1)
 
     visit "/merchants/#{merch1.id}/items"
+    save_and_open_page
+
+    within "#item-#{item1.id}" do
+      expect(page).to have_content(item1.name)
+      expect(page).to have_content(item1.status)
+      expect(page).to have_button("Disable #{item1.name}")
+      expect(page).to have_button("Enable #{item1.name}")
+
+      expect(page).to_not have_content(item2.name)
+      expect(page).to_not have_content(item2.status)
+      expect(page).to_not have_button("Disable #{item2.name}")
+      expect(page).to_not have_button("Enable #{item2.name}")
+    end
+
+    within "#item-#{item2.id}" do
+      expect(page).to_not have_content(item1.name)
+      expect(page).to_not have_content(item1.status)
+      expect(page).to_not have_button("Disable #{item1.name}")
+      expect(page).to_not have_button("Enable #{item1.name}")
+
+      expect(page).to have_content(item2.name)
+      expect(page).to have_content(item2.status)
+      expect(page).to have_button("Disable #{item2.name}")
+      expect(page).to have_button("Enable #{item2.name}")
+    end
 
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe 'merchants items index' do
     expect(page).to_not have_content(item5.name)
 
   end
+
+  it 'allows me to enable / disable items belonging to a merchant' do
+    # As a merchant
+    # When I visit my items index page
+    # Next to each item name I see a button to disable or enable that item.
+    # When I click this button
+    # Then I am redirected back to the items index
+    # And I see that the items status has changed
+    merch1 = Merchant.create!(name: 'Floopy Fopperations')
+    item1 = merch1.items.create!(name: 'Floopy Original', description: 'the best', unit_price: 450)
+    item2 = merch1.items.create!(name: 'Floopy Updated', description: 'the better', unit_price: 950)
+    item3 = merch1.items.create!(name: 'Floopy Retro', description: 'the OG', unit_price: 550)
+
+    visit "/merchants/#{merch1.id}/items"
+
+  end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'merchants items index' do
     item2 = merch1.items.create!(name: 'Floopy Updated', description: 'the better', unit_price: 950, status: 1)
 
     visit "/merchants/#{merch1.id}/items"
-    save_and_open_page
+    # save_and_open_page
 
     within "#item-#{item1.id}" do
       expect(page).to have_content(item1.name)
@@ -53,6 +53,8 @@ RSpec.describe 'merchants items index' do
       expect(page).to_not have_content(item2.status)
       expect(page).to_not have_button("Disable #{item2.name}")
       expect(page).to_not have_button("Enable #{item2.name}")
+
+      expect(page).to have_content("Current Status: disabled")
     end
 
     within "#item-#{item2.id}" do
@@ -65,6 +67,19 @@ RSpec.describe 'merchants items index' do
       expect(page).to have_content(item2.status)
       expect(page).to have_button("Disable #{item2.name}")
       expect(page).to have_button("Enable #{item2.name}")
+      expect(page).to have_content("Current Status: enabled")
+    end
+    #
+    #
+    click_button "Enable #{item1.name}"
+    click_button "Disable #{item2.name}"
+
+    within "#item-#{item1.id}" do
+      expect(page).to have_content("Current Status: enabled")
+    end
+
+    within "#item-#{item2.id}" do
+      expect(page).to have_content("Current Status: disabled")
     end
 
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe 'merchants items index' do
     #
     #
     click_button "Enable #{item1.name}"
-    click_button "Disable #{item2.name}"
-
+    expect(current_path).to eq("/merchants/#{merch1.id}/items/")
     within "#item-#{item1.id}" do
       expect(page).to have_content("Current Status: enabled")
     end
 
+    click_button "Disable #{item2.name}"
+    expect(current_path).to eq("/merchants/#{merch1.id}/items/")
     within "#item-#{item2.id}" do
       expect(page).to have_content("Current Status: disabled")
     end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe 'merchants items index' do
   end
 
   it "shows a link to update item information and displays a flash message when successful" do
+    # As a merchant,
+    # When I visit the merchant show page of an item
+    # I see a link to update the item information.
+    # When I click the link
+    # Then I am taken to a page to edit this item
+    # And I see a form filled in with the existing item attribute information
+    # When I update the information in the form and I click ‘submit’
+    # Then I am redirected back to the item show page where I see the updated information
+    # And I see a flash message stating that the information has been successfully updated.
+
     merch1 = Merchant.create!(name: 'Floopy Fopperations')
     item1 = merch1.items.create!(name: 'Floopy Original', description: 'the best', unit_price: 450)
     item2 = merch1.items.create!(name: 'Floopy Updated', description: 'the better', unit_price: 950)
@@ -46,10 +56,10 @@ RSpec.describe 'merchants items index' do
     fill_in :description, with: 'New and Improved'
     click_button 'Update Item'
     expect(current_path).to eq("/merchants/#{merch1.id}/items/#{item1.id}")
-    expect(page).to have_content("Floopy New")  
+    expect(page).to have_content("Floopy New")
     expect(page).to have_content("New and Improved")
     expect(page).to have_content("450")
     expect(page).to have_content("Success: Item information has been updated.")
   end
-  
+
 end


### PR DESCRIPTION
All,

This PR will allow us to enable / disable items on a merchant's item index page.  I modified the controller slightly to handle the different status.  

Also a migration was created to modify our item table to include an enum. 

Let me know if you have any questions.

-Jim